### PR TITLE
Introduce modules for operations on register value

### DIFF
--- a/app/ptx_asm/reg_utils/ptx_conversion.h
+++ b/app/ptx_asm/reg_utils/ptx_conversion.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <ptx_types.h>
+#include <reg_utils/ptx_type_traits.h>
+
+namespace Emulator::Ptx::RegUtils::Conv
+{
+
+/// @brief Casts a register storage value to a corresponding C++ type.
+/// @tparam ptxType Source PTX data type.
+/// @param src Source register value.
+/// @return Cast register value.
+template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+inline ValueType& Cast(void* pValue);
+/// @brief Casts a register storage value to a corresponding C++ type.
+/// @tparam ptxType Source PTX data type.
+/// @param src Source register value.
+/// @return Cast register value.
+template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+inline const ValueType& Cast(const void* pValue);
+
+/// @brief Writes a value of a corresponding C++ type to a register storage.
+/// @tparam ptxType Source PTX data type.
+/// @param pDst Destination register storage.
+/// @param value Value to be written.
+template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+inline void Write(void* pDst, const ValueType& value);
+
+/// @brief Copies a value from one register storage to another.
+/// @tparam ptxType PTX data type of the stored data.
+/// @param pSrc Source register storage.
+/// @param pDst Destination register storage.
+template <dataType ptxType>
+inline void Copy(const void* pSrc, void* pDst);
+
+/// @brief Converts bytes of reg storage from one ptx type to another.
+/// @tparam srcPtxType Source PTX data type.
+/// @tparam dstPtxType Destination PTX data type.
+/// @param src Source register value.
+/// @return Converted register value.
+template <dataType srcPtxType, dataType dstPtxType>
+inline void Convert(const void* pSrc, void* pDst);
+
+#pragma region detail
+
+template <dataType ptxType, typename ValueType>
+ValueType& Cast(void* pValue)
+{
+    __EMULATOR_PTX_REG_UTILS_TYPE_TRAITS_CHECK_VALUE_TYPE(ValueType);
+
+    return *reinterpret_cast<ValueType*>(pValue);
+}
+template <dataType ptxType, typename ValueType>
+const ValueType& Cast(const void* pValue)
+{
+    __EMULATOR_PTX_REG_UTILS_TYPE_TRAITS_CHECK_VALUE_TYPE(ValueType);
+
+    return *reinterpret_cast<const ValueType*>(pValue);
+}
+
+template <dataType ptxType, typename ValueType>
+void Write(void* pDst, const ValueType& value)
+{
+    __EMULATOR_PTX_REG_UTILS_TYPE_TRAITS_CHECK_VALUE_TYPE(ValueType);
+
+    Cast<ptxType>(pDst) = value;
+}
+
+template <dataType ptxType>
+void Copy(const void* pSrc, void* pDst)
+{
+    Cast<ptxType>(pDst) = Cast<ptxType>(pSrc);
+}
+
+template <dataType srcPtxType, dataType dstPtxType>
+void Convert(const void* pSrc, void* pDst)
+{
+    static_assert(srcPtxType != dstPtxType,
+                  "Source and destination types must be different. Use copy instead.");
+
+    using DstType = TypeTraits::CType<dstPtxType>;
+    __EMULATOR_PTX_REG_UTILS_TYPE_TRAITS_CHECK_VALUE_TYPE(DstType);
+
+    Cast<dstPtxType>(pDst) = static_cast<DstType>(Cast<srcPtxType>(pSrc));
+}
+
+#pragma endregion detail
+
+}  // namespace Emulator::Ptx::RegUtils::Conv

--- a/app/ptx_asm/reg_utils/ptx_maths.h
+++ b/app/ptx_asm/reg_utils/ptx_maths.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <ptx_types.h>
+#include <reg_utils/ptx_type_traits.h>
+#include <reg_utils/ptx_conversion.h>
+
+namespace Emulator::Ptx::RegUtils::Maths
+{
+
+/// @brief Adds two register values of the same PTX data type.
+/// @tparam ptxType Source PTX data type.
+/// @param rhs Right-hand side register value.
+/// @param lhs Left-hand side register value.
+/// @return Result of the addition.
+template <dataType ptxType>
+inline void Add(const void* pLhs, const void* pRhs, void* pRet);
+
+/// @brief Subtracts two register values of the same PTX data type.
+/// @tparam ptxType Source PTX data type.
+/// @param rhs Right-hand side register value.
+/// @param lhs Left-hand side register value.
+/// @param ret Result of the subtraction.
+template <dataType ptxType>
+inline void Sub(const void* pLhs, const void* pRhs, void* pRet);
+
+/// @brief Multiplies two register values of the same PTX data type.
+/// @tparam ptxType Source PTX data type.
+/// @param rhs Right-hand side register value.
+/// @param lhs Left-hand side register value.
+/// @param ret Result of the multiplication.
+template <dataType ptxType, mulmodeQl mulMode>
+inline void Mul(const void* pLhs, const void* pRhs, void* pRet);
+
+/// @brief Divides two register values of the same PTX data type.
+/// @tparam ptxType PTX data type.
+/// @param rhs Right-hand side register value.
+/// @param lhs Left-hand side register value.
+/// @param ret Result of the division.
+template <dataType ptxType>
+inline void Div(const void* pLhs, const void* pRhs, void* pRet);
+
+// TODO: Other operations
+
+#pragma region detail
+
+namespace detail
+{
+
+// Binary
+
+template <typename T>
+struct __AddOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs + rhs;
+    }
+};
+
+template <typename T>
+struct __SubOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs - rhs;
+    }
+};
+
+template <typename T>
+struct __MulOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs * rhs;
+    }
+};
+
+template <typename T>
+struct __DivOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs / rhs;
+    }
+};
+
+template <typename T>
+struct __AndOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs & rhs;
+    }
+};
+
+template <typename T>
+struct __OrOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs | rhs;
+    }
+};
+
+template <dataType ptxType, typename Op>
+inline void __Apply(const void* pLhs, const void* pRhs, void* pDst)
+{
+    using Type = TypeTraits::CType<ptxType>;
+
+    const Type& lhsValue = Conv::Cast<ptxType>(pLhs);
+    const Type& rhsValue = Conv::Cast<ptxType>(pRhs);
+    Type&       dstValue = Conv::Cast<ptxType>(pDst);
+
+    dstValue = Op{}(lhsValue, rhsValue);
+}
+
+// Unary
+
+template <typename T>
+struct __XorOp
+{
+    T operator()(const T& lhs, const T& rhs) const
+    {
+        return lhs ^ rhs;
+    }
+};
+
+template <typename T>
+struct __NotOp
+{
+    T operator()(const T& value) const
+    {
+        return ~value;
+    }
+};
+
+template <typename T>
+struct __CNotOp
+{
+    T operator()(const T& value) const
+    {
+        return (value == 0) ? 1 : 0;
+    }
+};
+
+template <dataType ptxType, typename Op>
+inline void __Apply(const void* pSrc, void* pDst)
+{
+    using Type = TypeTraits::CType<ptxType>;
+
+    const Type& srcValue = Conv::Cast<ptxType>(pSrc);
+    Type&       dstValue = Conv::Cast<ptxType>(pDst);
+
+    dstValue = Op{}(srcValue);
+}
+
+} // namespace detail
+
+template <dataType ptxType>
+void Add(const void* pLhs, const void* pRhs, void* pRet)
+{
+    detail::__Apply<ptxType, detail::__AddOp>(pRhs, pLhs, pRet);
+}
+
+template <dataType ptxType>
+void Sub(const void* pLhs, const void* pRhs, void* pRet)
+{
+    detail::__Apply<ptxType, detail::__SubOp>(pRhs, pLhs, pRet);
+}
+
+template <dataType ptxType, mulmodeQl mulMode>
+void Mul(const void* pLhs, const void* pRhs, void* pRet)
+{
+    constexpr dataType srcPtxType  = ptxType;
+    constexpr dataType calcPtxType = TypeTraits::doubleOrSameType<srcPtxType>;
+    using SrcType  = TypeTraits::CType<srcPtxType>;
+    using CalcType = TypeTraits::CType<calcPtxType>;
+
+    const CalcType lhsValue   = static_cast<CalcType>(Conv::Cast<srcPtxType>(pLhs));
+    const CalcType rhsValue   = static_cast<CalcType>(Conv::Cast<srcPtxType>(pRhs));
+    CalcType       tempResult = 0xDEADBEEFDEADBEEF;
+
+    detail::__Apply<calcPtxType>(static_cast<const void*>(&lhsValue),
+                                 static_cast<const void*>(&rhsValue),
+                                 static_cast<void*>(&tempResult));
+
+    if constexpr (mulMode == mulmodeQl::Wide)
+    {
+        Conv::Write<calcPtxType>(pRet, tempResult);
+    }
+    else if constexpr (mulMode == mulmodeQl::Hi)
+    {
+        static_assert(srcPtxType != calcPtxType,
+                      "High multiplication mode requires a double type which is undefined.");
+
+        // shift left to keep the high bits
+        tempResult << (sizeof(SrcType) * 8);
+        Conv::Write<srcPtxType>(pRet, static_cast<SrcType>(tempResult));
+    } else if constexpr (mulMode == mulmodeQl::Lo)
+    {
+        // implictly keep the low bits by writing the value directly to a smaller type
+        Conv::Write<srcPtxType>(pRet, static_cast<SrcType>(tempResult));
+    }
+}
+
+template <dataType ptxType>
+void Div(const void* pLhs, const void* pRhs, void* pRet)
+{
+    detail::__Apply<ptxType, detail::__DivOp>(pRhs, pLhs, pRet);
+}
+
+#pragma endregion detail
+
+} // namespace Emulator::Ptx::RegUtils::Maths

--- a/app/ptx_asm/reg_utils/ptx_reg_storage.h
+++ b/app/ptx_asm/reg_utils/ptx_reg_storage.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include <ptx_types.h>
+#include <reg_utils/ptx_conversion.h>
+#include <reg_utils/ptx_maths.h>
+#include <reg_utils/ptx_type_traits.h>
+
+namespace Emulator::Ptx::RegUtils::RegStorage
+{
+
+/// @brief Type of the universal storage for a register which can hold any
+/// supported register value.
+using RegStorageType = uint64_t;
+
+/// @brief Class representing the storage of a register which can hold any supported register value.
+/// Is provided by operators for basic arithmetic operations on the stored value.
+class RegStorage {
+
+  // Intilization
+  public:
+
+    RegStorage()  noexcept = default;
+    ~RegStorage() noexcept = default;
+
+    explicit RegStorage(RegStorageType storage) noexcept : storage_{storage} {}
+    RegStorage& operator = (RegStorageType storage) noexcept
+    {
+        storage_ = storage;
+        return *this;
+    }
+
+    template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+    RegStorage(const ValueType& value) noexcept
+    {
+        Set<ptxType>(value);
+    }
+    template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+    RegStorage& operator = (const ValueType& value) noexcept
+    {
+        Set<ptxType>(value);
+        return *this;
+    }
+
+    template <dataType ptxType>
+    RegStorage(void* pValue) noexcept {
+        Conv::Copy<ptxType>(pValue, Data());
+    }
+
+    RegStorage(const RegStorage& other) noexcept            = default;
+    RegStorage& operator=(const RegStorage& other) noexcept = default;
+
+    RegStorage(RegStorage&& other) noexcept : storage_{other.Release()} {}
+    RegStorage& operator=(RegStorage&& other) noexcept
+    {
+        if (this != &other)
+        {
+            storage_ = other.Release();
+        }
+        return *this;
+    }
+
+  // Accessors
+  public:
+
+    template <dataType ptxType>
+    [[nodiscard]] inline TypeTraits::CType<ptxType>&       Get()       { return Conv::Cast<ptxType>(Data()); }
+    template <dataType ptxType>
+    [[nodiscard]] inline const TypeTraits::CType<ptxType>& Get() const { return Conv::Cast<ptxType>(Data()); }
+
+    template <dataType ptxType, typename ValueType = TypeTraits::CType<ptxType>>
+    void Set(const ValueType& value)
+    {
+        Conv::Write<ptxType>(Data(), value);
+    }
+
+    [[nodiscard]] RegStorageType Release() noexcept
+    {
+        RegStorageType ret = storage_;
+        Reset();
+        return ret;
+    }
+
+  // Internal
+  private:
+
+    void Reset() noexcept { storage_ = kUndefinedValue; }
+
+    [[nodiscard]] inline void*       Data() noexcept       { return &storage_; }
+    [[nodiscard]] inline const void* Data() const noexcept { return &storage_; }
+
+    RegStorageType storage_ = kUndefinedValue;
+
+    static constexpr RegStorageType kUndefinedValue = 0xDEADBEEFDEADBEEF;
+}; // class RegStorage
+
+/// @brief Performs addition operation.
+template <dataType ptxType>
+static RegStorage Add(const RegStorage& lhs, const RegStorage& rhs)
+{
+    RegStorage result;
+    Maths::Add<ptxType>(lhs.Data(), rhs.Data(), result.Data());
+    return result;
+}
+
+/// @brief Performs subtraction operation.
+template <dataType ptxType>
+static RegStorage Sub(const RegStorage& lhs, const RegStorage& rhs)
+{
+    RegStorage result;
+    Maths::Sub<ptxType>(lhs.Data(), rhs.Data(), result.Data());
+    return result;
+}
+
+/// @brief Performs multiplication operation with mode.
+template <dataType ptxType, mulmodeQl mulMode>
+static RegStorage Mul(const RegStorage& lhs, const RegStorage& rhs)
+{
+    RegStorage result;
+    Maths::Mul<ptxType, mulMode>(lhs.Data(), rhs.Data(), result.Data());
+    return result;
+}
+
+/// @brief Performs division operation.
+template <dataType ptxType>
+static RegStorage Div(const RegStorage& lhs, const RegStorage& rhs)
+{
+    RegStorage result;
+    Maths::Div<ptxType>(lhs.Data(), rhs.Data(), result.Data());
+    return result;
+}
+
+// TODO: Other operations
+
+/// @brief Wrapper register storage class for passing modifiable registers to instruction handlers.
+/// Provided in-memory register value is automatilly evaluated on destroy.
+class RegStorageWrapper
+{
+  public:
+
+    explicit RegStorageWrapper(RegStorageType& reg) noexcept
+        : pReg_{&reg}
+        , storage_{*pReg_} {}
+
+    ~RegStorageWrapper() noexcept { Release(); }
+
+    RegStorageWrapper(RegStorageWrapper&& other) noexcept
+    {
+        if (this != &other)
+        {
+            Release();
+            pReg_ = other.pReg_;
+            other.pReg_ = nullptr;
+        }
+    }
+    RegStorageWrapper& operator=(RegStorageWrapper&& other) noexcept
+    {
+        if (this != &other)
+        {
+            Release();
+            pReg_ = other.pReg_;
+            other.pReg_ = nullptr;
+        }
+        return *this;
+    }
+
+    RegStorageWrapper() = delete;
+    RegStorageWrapper(const RegStorageWrapper& other) noexcept = delete;
+    RegStorageWrapper& operator=(const RegStorageWrapper& other) noexcept = delete;
+
+    inline operator RegStorage&()       noexcept       { return storage_; }
+    inline operator const RegStorage&() const noexcept { return storage_; }
+
+  private:
+
+    void Release() noexcept
+    {
+        *pReg_ = storage_.Release();
+    }
+
+    RegStorageType* pReg_ = nullptr;
+
+    RegStorage storage_;
+}; // class RegStorageWrapper
+
+/**
+ * Usage example:
+ *
+ *    // For some intruction, e.g.
+ *    // "add.u32 r1, r2, r3;"
+ *
+ *
+ *          // Auto-generated thread instruction handler
+ *          ...
+ *
+ *          uint64_t&       r1Data; // it's read from memory for "r1" register
+ *          const uint64_t& r2Data; // for "r2" register
+ *          const uint64_t& r3Data; // for "r3" register
+ *          // this `uint64_t` is the `RegStorage::RegStorageType`
+ *
+ *          RegStorage::RegStorageWrapper r1{r1Data}; // create wrapper for "r1" register
+ *          const RegStorage::RegStorage  r2{r2Data}; // ... "r2"
+ *          const RegStorage::RegStorage  r3{r3Data}; // ... "r3"
+ *          // it is also possible to make all three registers as non-const wrappers for generality
+ *
+ *    ----  Add<...>(r1, r2, r3); // call the customizable instruction handler
+ *    |     // on handler destroy, `r1Data` is implicitly evaluated with the value in `r1`
+ *    |
+ *    |
+ *    |              // Customizable instruction handler for "add" instruction
+ *    |              template <..., dataType ptxType, ...>
+ *    ----------->   void Add(RegStorage::RegStorage&       dst,
+ *                            const RegStorage::RegStorage& src1,
+ *                            const RegStorage::RegStorage& src2)
+ *                   {
+ *                       dst = RegStorage::Add<ptxType>(src1, src2);
+ *                   }
+ */
+
+} // namespace Emulator::Ptx::RegUtils::RegStorage

--- a/app/ptx_asm/reg_utils/ptx_type_traits.h
+++ b/app/ptx_asm/reg_utils/ptx_type_traits.h
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <ptx_types.h>
+
+#include <cstdint>
+#include <stdfloat>
+#include <type_traits>
+
+#define __CPP_FIXED_FLOAT_LIBRARY_SUPPORT (__STDCPP_FLOAT16_T__ == 1)
+
+namespace Emulator::Ptx::RegUtils::TypeTraits
+{
+
+#pragma region detail
+
+namespace detail
+{
+
+struct __UndefinedType {};
+
+template <typename T>
+constexpr bool __isUndefined = std::is_same_v<T, __UndefinedType>;
+
+template <dataType ptxType>
+using __CType =
+    // floating point types
+#if __CPP_FIXED_FLOAT_LIBRARY_SUPPORT
+    std::conditional_t<ptxType == dataType::F16,    std::float16_t,
+    // TODO: std::conditional_t<ptxType == dataType::F16X2,  std::bfloat16_t,
+    std::conditional_t<ptxType == dataType::F32,    std::float32_t,
+    std::conditional_t<ptxType == dataType::F64,    std::float64_t,
+#else
+    std::conditional_t<ptxType == dataType::F16,    float,
+    // TODO: std::conditional_t<ptxType == dataType::F16X2,  float,
+    std::conditional_t<ptxType == dataType::F32,    std::conditional_t<sizeof(float) == 4, float, double>,
+    std::conditional_t<ptxType == dataType::F64,    double,
+#endif
+
+    // signed integer types
+    std::conditional_t<ptxType == dataType::S8,     int8_t,
+    std::conditional_t<ptxType == dataType::S16,    int16_t,
+    std::conditional_t<ptxType == dataType::S32,    int32_t,
+    std::conditional_t<ptxType == dataType::S64,    int64_t,
+
+    // unsigned integer types
+    std::conditional_t<ptxType == dataType::U8,     uint8_t,
+    std::conditional_t<ptxType == dataType::U16,    uint16_t,
+    std::conditional_t<ptxType == dataType::U32,    uint32_t,
+    std::conditional_t<ptxType == dataType::U64,    uint64_t,
+
+    // byte types
+    std::conditional_t<ptxType == dataType::B8,     uint8_t,
+    std::conditional_t<ptxType == dataType::B16,    uint16_t,
+    std::conditional_t<ptxType == dataType::B32,    uint32_t,
+    std::conditional_t<ptxType == dataType::B64,    uint64_t,
+    // TODO: dataType::B128
+
+    // default value
+    __UndefinedType>>>>>>>>>>>>>>>;
+
+template <dataType ptxType>
+constexpr bool __isFloatingPoint =
+    (ptxType == dataType::F16)   ||
+    // TODO: (ptxType == dataType::F16X2) ||
+    (ptxType == dataType::F32)   ||
+    (ptxType == dataType::F64);
+
+template <dataType ptxType>
+constexpr bool __isUnsignedInteger =
+    (ptxType == dataType::U8)  ||
+    (ptxType == dataType::U16) ||
+    (ptxType == dataType::U32) ||
+    (ptxType == dataType::U64);
+
+template <dataType ptxType>
+constexpr bool __isSignedInteger =
+    (ptxType == dataType::S8)  ||
+    (ptxType == dataType::S16) ||
+    (ptxType == dataType::S32) ||
+    (ptxType == dataType::S64);
+
+template <dataType ptxType>
+constexpr bool __isByte =
+    (ptxType == dataType::B8)  ||
+    (ptxType == dataType::B16) ||
+    (ptxType == dataType::B32) ||
+    (ptxType == dataType::B64);
+    // TODO: (ptxType == dataType::B128)
+
+template <dataType ptxType>
+constexpr bool __isPredicate = (ptxType == dataType::Pred);
+
+template <dataType ptxType>
+constexpr dataType __GetDoublePtxType()
+{
+    // floating point types
+    if constexpr (ptxType == dataType::F16) return dataType::F32;
+    if constexpr (ptxType == dataType::F32) return dataType::F64;
+
+    // signed integer types
+    if constexpr (ptxType == dataType::S8)  return dataType::S16;
+    if constexpr (ptxType == dataType::S16) return dataType::S32;
+    if constexpr (ptxType == dataType::S32) return dataType::S64;
+
+    // unsigned integer types
+    if constexpr (ptxType == dataType::U8)  return dataType::U16;
+    if constexpr (ptxType == dataType::U16) return dataType::U32;
+    if constexpr (ptxType == dataType::U32) return dataType::U64;
+
+    // byte types
+    if constexpr (ptxType == dataType::B8)  return dataType::B16;
+    if constexpr (ptxType == dataType::B16) return dataType::B32;
+    if constexpr (ptxType == dataType::B32) return dataType::B64;
+    // TODO: if constexpr (ptxType == dataType::B64) return dataType::B128;
+
+    return dataType::UNDEFINED;
+}
+
+template <dataType ptxType>
+constexpr bool __IsFinalDoubleType()
+{
+    // floating point types
+    if constexpr (ptxType == dataType::F64) return true;
+
+    // signed integer types
+    if constexpr (ptxType == dataType::S64) return true;
+
+    // unsigned integer types
+    if constexpr (ptxType == dataType::U64) return true;
+
+    // unsigned integer types
+    if constexpr (ptxType == dataType::B64) return true; // TODO: B128
+
+    return false;
+}
+
+#define __EMULATOR_PTX_REG_UTILS_TYPE_TRAITS_CHECK_VALUE_TYPE(type)                    \
+    static_assert(!::Emulator::Ptx::RegUtils::TypeTraits::detail::__isUndefined<type>, \
+                  "Undefined type")
+
+} // namespace detail
+
+#pragma endregion detail
+
+/// @brief Retuns the corresponding C++ type for a given PTX data type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+using CType = detail::__CType<ptxType>;
+
+/// @brief Retuns the corresponding PTX data type which is the "double" of a given PTX data type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr dataType doubleType = detail::__GetDoublePtxType<ptxType>();
+
+/// @brief Returns the corresponding PTX data type which is the "double" of a given PTX data type, or the same type if no double type exists.
+/// @tparam ptxType
+template <dataType ptxType>
+constexpr dataType doubleOrSameType =
+    (detail::__IsFinalDoubleType<ptxType>()) ? ptxType : doubleType<ptxType>;
+
+/// @brief Checks if a PTX data type is a floating-point type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isFloatingPoint = detail::__isFloatingPoint<ptxType>;
+
+/// @brief Checks if a PTX data type is an integer type (signed or unsigned).
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isInteger = detail::__isUnsignedInteger<ptxType> ||
+                           detail::__isSignedInteger<ptxType>;
+
+/// @brief Checks if a PTX data type is an unsigned integer type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isUnsigned = detail::__isUnsignedInteger<ptxType>;
+
+/// @brief Checks if a PTX data type is a signed integer type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isSigned = detail::__isSignedInteger<ptxType>;
+
+/// @brief Checks if a PTX data type is a byte type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isByte = detail::__isByte<ptxType>;
+
+/// @brief Checks if a PTX data type is a predicate type.
+/// @tparam ptxType Source PTX data type.
+template <dataType ptxType>
+constexpr bool isPredicate = detail::__isPredicate<ptxType>;
+
+} // namespace Emulator::Ptx::RegUtils::TypeTraits


### PR DESCRIPTION
Adds 3 new inline modules:
- `ptx_type_traits` Provides basic access/write operations on data. Here data is defined as constexpression type and value as void-pointer.
- `ptx_maths` Provides math operations on data with format same as previous. Supported operations: Add, Div, Mul (Wide,Hi,Lo), Div.
- `reg_storage` Provides storage class manipulating register value. Overrides all basic and maths operation for the storage. Provides wrapper class holding in-memory register value by pointer and manipulating the value through proxy storage instance.

Each module expects the PTX operation type as compile-time value.

TBD:
- Cover these modules with unit-tests.