### PR TITLE
Improve CUDA samples testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(cpp_template)
 
+option(BUILD_CUDA_SAMPLES OFF "Build CUDA samples")
+
 include(cmake/configure.cmake)
 
 include_directories(include)
@@ -10,6 +12,4 @@ enable_testing()
 
 add_subdirectory(3rdparty)
 add_subdirectory(app)
-# add_subdirectory(src)
 add_subdirectory(test)
-

--- a/app/emulator/main.cpp
+++ b/app/emulator/main.cpp
@@ -1,6 +1,32 @@
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <string>
+
+namespace fs = std::filesystem;
+
+constexpr const char* RuntimeLibName = "libemuruntime.so";
+
+static fs::path GetExecutableDir()
+{
+    std::error_code ec;
+    auto exe_path = fs::read_symlink("/proc/self/exe", ec);
+    if (!ec)
+    {
+        auto dir = exe_path.parent_path();
+        if (!dir.empty())
+        {
+            return dir;
+        }
+    }
+    return ".";
+}
+
+static fs::path GetLibDir()
+{
+    fs::path lib_path = GetExecutableDir() / ".." / "lib";
+    return lib_path.lexically_normal();
+}
 
 int main(int argc, char* argv[])
 {
@@ -9,10 +35,14 @@ int main(int argc, char* argv[])
         std::cerr << "Usage: " << argv[0] << " <binary>\n";
         return 1;
     }
-    std::string file = argv[1];
-    auto cmd = std::string("LD_PRELOAD=libemuruntime.so CUEMU_TARGET_EXEC=");
+    const std::string file = argv[1];
+
+    std::string cmd;
+    cmd += "PATH=" + GetExecutableDir().string() + ":$PATH" + " ";
+    cmd += "LD_LIBRARY_PATH=" + GetLibDir().string() + ":$LD_LIBRARY_PATH" + " ";
+    cmd += "LD_PRELOAD=" + std::string(RuntimeLibName) + " ";
+    cmd += "CUEMU_TARGET_EXEC=" + file + " ";
     cmd += file;
-    cmd += " ";
-    cmd += file;
+
     return system(cmd.c_str());
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(unit)
+
+if(BUILD_CUDA_SAMPLES)
+    add_subdirectory(ptx_sources)
+endif()

--- a/test/ptx_sources/CMakeLists.txt
+++ b/test/ptx_sources/CMakeLists.txt
@@ -1,0 +1,34 @@
+message(STATUS "Building CUDA samples")
+
+find_program(NVCC_EXECUTABLE nvcc)
+if(NOT NVCC_EXECUTABLE)
+  message(FATAL_ERROR "nvcc not found. Install CUDA toolkit or make nvcc available on PATH.")
+endif()
+
+set(SAMPLE_SOURCES_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB SAMPLE_SOURCES "${SAMPLE_SOURCES_DIR}/*.cu")
+if(NOT SAMPLE_SOURCES)
+  message(FATAL_ERROR "No CUDA source files found in ${SAMPLE_SOURCES_DIR}")
+endif()
+
+set(SAMPLE_EXECUTABLES "")
+foreach(SAMPLE_SOURCE IN LISTS SAMPLE_SOURCES)
+  get_filename_component(SAMPLE_NAME ${SAMPLE_SOURCE} NAME_WE)
+  set(SAMPLE_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/cuda_samples")
+  set(SAMPLE_EXECUTABLE "${SAMPLE_OUTPUT_DIR}/${SAMPLE_NAME}")
+
+  add_custom_command(
+    OUTPUT ${SAMPLE_EXECUTABLE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${SAMPLE_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E echo "Building sample: ${SAMPLE_NAME}"
+    COMMAND ${NVCC_EXECUTABLE} ${SAMPLE_SOURCE} -o ${SAMPLE_EXECUTABLE} --cudart=shared
+    DEPENDS ${SAMPLE_SOURCE}
+    WORKING_DIRECTORY ${SAMPLE_SOURCES_DIR}
+    VERBATIM
+  )
+
+  list(APPEND SAMPLE_EXECUTABLES ${SAMPLE_EXECUTABLE})
+endforeach()
+
+add_custom_target(cuda_samples ALL DEPENDS ${SAMPLE_EXECUTABLES})


### PR DESCRIPTION
- Automatic preloaded lib path setting. Setting `LD_LIBRARY_PATH` is nomore needed.
  Assumes the libs are located next to bins in separate folder. If library path is not default, user can still specify it by setting `LD_LIBRARY_PATH``.
- Added CMake option for compiling provided CUDA samples.